### PR TITLE
Add scaladocs and updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ ThisBuild / scalaVersion := Scala213 // the default Scala
 
 val catsV = "2.8.0"
 val catsEffectV = "3.3.14"
-val fs2V = "3.2.10"
+val fs2V = "3.2.11"
 val munitCatsEffectV = "1.0.7"
 val luceneV = "9.2.0"
 

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val catsV = "2.8.0"
 val catsEffectV = "3.3.14"
 val fs2V = "3.2.11"
 val munitCatsEffectV = "1.0.7"
-val luceneV = "9.2.0"
+val luceneV = "9.3.0"
 
 lazy val root = tlCrossRootProject.aggregate(core, lucene)
 

--- a/lucene/src/main/scala/textmogrify/lucene/AnalyzerBuilder.scala
+++ b/lucene/src/main/scala/textmogrify/lucene/AnalyzerBuilder.scala
@@ -46,15 +46,26 @@ final class AnalyzerBuilder private (
       stopWords = stopWords,
     )
 
+  /** Adds a lowercasing stage to the analyzer pipeline */
   def withLowerCasing: AnalyzerBuilder =
     copy(lowerCase = true)
 
+  /** Adds an ASCII folding stage to the analyzer pipeline
+    * ASCII folding converts alphanumeric and symbolic Unicode characters into
+    * their ASCII equivalents, if one exists.
+    */
   def withASCIIFolding: AnalyzerBuilder =
     copy(foldASCII = true)
 
+  /** Adds the Porter Stemmer to the end of the analyzer pipeline and enables lowercasing.
+    * Stemming reduces words like `jumping` and `jumps` to their root word `jump`.
+    * NOTE: Lowercasing is forced as it is required for the Lucene PorterStemFilter.
+    */
   def withPorterStemmer: AnalyzerBuilder =
-    copy(stemmer = true)
+    copy(stemmer = true, lowerCase = true)
 
+  /** Adds a stop filter stage to analyzer pipeline for non-empty sets.
+    */
   def withStopWords(words: Set[String]): AnalyzerBuilder =
     copy(stopWords = words)
 


### PR DESCRIPTION
Of note, this PR forces lowercasing with using `withPorterStemmer` which was always required by Lucene anyways.