### PR TITLE
Remove github-app-token from update-flake

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -11,17 +11,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install Nix
-        uses: cachix/install-nix-action@v16
+        uses: cachix/install-nix-action@v17
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: tibdex/github-app-token@v1
-        id: generate-token
-        with:
-          app_id: 207529
-          private_key: ${{ secrets.STEWARD_PRIVATE_KEY }}
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v10
+        uses: DeterminateSystems/update-flake-lock@v13
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           branch: update/flake-lock-${{ github.run_number }}


### PR DESCRIPTION
Removing the "impersonation" of Typelevel Steward and going with a personal auth token.

Followed instructions from here:
https://github.com/DeterminateSystems/update-flake-lock#with-a-personal-authentication-token

Created a 90 day token to start.