### PR TITLE
Separate Custom & Default Stop Filters

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ import fs2.Pipe
 val normalizeMsgs: Pipe[IO, Msg, Doc] = msgs => {
   val tokenizer = AnalyzerBuilder.english
     .withLowerCasing
-    .withStopWords(Set("how", "do", "i", "my"))
+    .withCustomStopWords(Set("how", "do", "i", "my"))
     .withPorterStemmer
     .tokenizer[IO]
   Stream.resource(tokenizer)

--- a/example/src/main/scala/textmogrify/MultiLingualPipeline.scala
+++ b/example/src/main/scala/textmogrify/MultiLingualPipeline.scala
@@ -41,7 +41,7 @@ object MultiLingualPipeline extends IOApp.Simple {
   )
 
   def multiTokenizer: Resource[IO, Msg => IO[Vector[String]]] = {
-    val base = AnalyzerBuilder.default.withLowerCasing.withASCIIFolding
+    val base = AnalyzerBuilder.default.withLowerCasing.withASCIIFolding.withDefaultStopWords
 
     val englishA = base.english.withPorterStemmer.tokenizer[IO]
     val frenchA = base.french.withFrenchLightStemmer.tokenizer[IO]

--- a/example/src/main/scala/textmogrify/Pipeline.scala
+++ b/example/src/main/scala/textmogrify/Pipeline.scala
@@ -33,7 +33,7 @@ object Pipeline extends IOApp.Simple {
 
   val tokenizeMsgs: Pipe[IO, Msg, Doc] = msgs => {
     val tokenizer = AnalyzerBuilder.english.withLowerCasing
-      .withStopWords(Set("how", "do", "i", "my"))
+      .withCustomStopWords(Set("how", "do", "i", "my"))
       .withPorterStemmer
       .tokenizer[IO]
     Stream

--- a/lucene/src/main/scala/textmogrify/lucene/AnalyzerBuilder.scala
+++ b/lucene/src/main/scala/textmogrify/lucene/AnalyzerBuilder.scala
@@ -169,7 +169,8 @@ final class EnglishAnalyzerBuilder private[lucene] (
     * This set is immutable, and unused; it is the underlying Lucene `CharArraySet` that we use to
     * build the default StopFilter
     */
-  lazy val defaultStopWords: Set[String] = getEnglishStopSet().asScala.map(_.toString()).toSet
+  lazy val defaultStopWords: Set[String] =
+    getEnglishStopSet().asScala.map(ca => String.valueOf(ca.asInstanceOf[Array[Char]])).toSet
 
   /** Adds the Porter Stemmer to the end of the analyzer pipeline and enables lowercasing.
     * Stemming reduces words like `jumping` and `jumps` to their root word `jump`.
@@ -205,7 +206,8 @@ final class FrenchAnalyzerBuilder private[lucene] (
     * This set is immutable, and unused; it is the underlying Lucene `CharArraySet` that we use to
     * build the default StopFilter
     */
-  lazy val defaultStopWords: Set[String] = getFrenchStopSet().asScala.map(_.toString()).toSet
+  lazy val defaultStopWords: Set[String] =
+    getFrenchStopSet().asScala.map(ca => String.valueOf(ca.asInstanceOf[Array[Char]])).toSet
 
   /** Adds the FrenchLight Stemmer to the end of the analyzer pipeline and enables lowercasing.
     * Stemming reduces words like `jumping` and `jumps` to their root word `jump`.
@@ -240,7 +242,8 @@ final class SpanishAnalyzerBuilder private[lucene] (
     * This set is immutable, and unused; it is the underlying Lucene `CharArraySet` that we use to
     * build the default StopFilter
     */
-  lazy val defaultStopWords: Set[String] = getSpanishStopSet().asScala.map(_.toString()).toSet
+  lazy val defaultStopWords: Set[String] =
+    getSpanishStopSet().asScala.map(ca => String.valueOf(ca.asInstanceOf[Array[Char]])).toSet
 
   /** Adds the SpanishLight Stemmer to the end of the analyzer pipeline and enables lowercasing.
     * Stemming reduces words like `jumping` and `jumps` to their root word `jump`.
@@ -275,7 +278,8 @@ final class ItalianAnalyzerBuilder private[lucene] (
     * This set is immutable, and unused; it is the underlying Lucene `CharArraySet` that we use to
     * build the default StopFilter
     */
-  lazy val defaultStopWords: Set[String] = getItalianStopSet().asScala.map(_.toString()).toSet
+  lazy val defaultStopWords: Set[String] =
+    getItalianStopSet().asScala.map(ca => String.valueOf(ca.asInstanceOf[Array[Char]])).toSet
 
   /** Adds the ItalianLight Stemmer to the end of the analyzer pipeline and enables lowercasing.
     * Stemming reduces words like `jumping` and `jumps` to their root word `jump`.
@@ -310,7 +314,8 @@ final class GermanAnalyzerBuilder private[lucene] (
     * This set is immutable, and unused; it is the underlying Lucene `CharArraySet` that we use to
     * build the default StopFilter
     */
-  lazy val defaultStopWords: Set[String] = getGermanStopSet().asScala.map(_.toString()).toSet
+  lazy val defaultStopWords: Set[String] =
+    getGermanStopSet().asScala.map(ca => String.valueOf(ca.asInstanceOf[Array[Char]])).toSet
 
   /** Adds the GermanLight Stemmer to the end of the analyzer pipeline and enables lowercasing.
     * Stemming reduces words like `jumping` and `jumps` to their root word `jump`.

--- a/lucene/src/main/scala/textmogrify/lucene/AnalyzerBuilder.scala
+++ b/lucene/src/main/scala/textmogrify/lucene/AnalyzerBuilder.scala
@@ -16,6 +16,8 @@
 
 package textmogrify.lucene
 
+import scala.jdk.CollectionConverters._
+
 import cats.effect.kernel.{Resource, Sync}
 import org.apache.lucene.analysis.Analyzer.TokenStreamComponents
 import org.apache.lucene.analysis.standard.StandardTokenizer
@@ -62,7 +64,7 @@ object Config {
 sealed abstract class AnalyzerBuilder private[lucene] (config: Config) {
   type Builder <: AnalyzerBuilder
 
-  def defaultStopWords: CharArraySet
+  def defaultStopWords: Set[String]
   def withConfig(config: Config): Builder
 
   /** Adds a lowercasing stage to the analyzer pipeline */
@@ -99,7 +101,6 @@ sealed abstract class AnalyzerBuilder private[lucene] (config: Config) {
         val source = new StandardTokenizer()
         var tokens = if (config.lowerCase) new LowerCaseFilter(source) else source
         tokens = if (config.foldASCII) new ASCIIFoldingFilter(tokens) else tokens
-        tokens = if (config.defaultStopWords) new StopFilter(tokens, defaultStopWords) else tokens
         tokens =
           if (config.customStopWords.isEmpty) tokens
           else {
@@ -131,7 +132,7 @@ final class DefaultAnalyzerBuilder private[lucene] (config: Config)
     extends AnalyzerBuilder(config) { self =>
   type Builder = DefaultAnalyzerBuilder
 
-  def defaultStopWords: CharArraySet = CharArraySet.EMPTY_SET
+  lazy val defaultStopWords: Set[String] = Set.empty
 
   def withConfig(newConfig: Config): DefaultAnalyzerBuilder =
     new DefaultAnalyzerBuilder(newConfig)
@@ -161,9 +162,14 @@ final class EnglishAnalyzerBuilder private[lucene] (
   ): EnglishAnalyzerBuilder =
     new EnglishAnalyzerBuilder(newConfig, stemmer)
 
-  def defaultStopWords: CharArraySet = getEnglishStopSet()
   def withConfig(newConfig: Config): EnglishAnalyzerBuilder =
     copy(newConfig = newConfig)
+
+  /** A convenience value for debugging or investigating, to inspect the Lucene default stop words.
+    * This set is immutable, and unused; it is the underlying Lucene `CharArraySet` that we use to
+    * build the default StopFilter
+    */
+  lazy val defaultStopWords: Set[String] = getEnglishStopSet().asScala.map(_.toString()).toSet
 
   /** Adds the Porter Stemmer to the end of the analyzer pipeline and enables lowercasing.
     * Stemming reduces words like `jumping` and `jumps` to their root word `jump`.
@@ -173,7 +179,11 @@ final class EnglishAnalyzerBuilder private[lucene] (
     copy(config.copy(lowerCase = true), stemmer = true)
 
   def build[F[_]](implicit F: Sync[F]): Resource[F, Analyzer] =
-    mkFromStandardTokenizer(config)(ts => if (self.stemmer) new PorterStemFilter(ts) else ts)
+    mkFromStandardTokenizer(config) { ts =>
+      val tokens =
+        if (self.config.defaultStopWords) new StopFilter(ts, getEnglishStopSet()) else ts
+      if (self.stemmer) new PorterStemFilter(tokens) else tokens
+    }
 }
 
 final class FrenchAnalyzerBuilder private[lucene] (
@@ -188,9 +198,14 @@ final class FrenchAnalyzerBuilder private[lucene] (
   ): FrenchAnalyzerBuilder =
     new FrenchAnalyzerBuilder(newConfig, stemmer)
 
-  def defaultStopWords: CharArraySet = getFrenchStopSet()
   def withConfig(newConfig: Config): FrenchAnalyzerBuilder =
     copy(newConfig = newConfig)
+
+  /** A convenience value for debugging or investigating, to inspect the Lucene default stop words.
+    * This set is immutable, and unused; it is the underlying Lucene `CharArraySet` that we use to
+    * build the default StopFilter
+    */
+  lazy val defaultStopWords: Set[String] = getFrenchStopSet().asScala.map(_.toString()).toSet
 
   /** Adds the FrenchLight Stemmer to the end of the analyzer pipeline and enables lowercasing.
     * Stemming reduces words like `jumping` and `jumps` to their root word `jump`.
@@ -200,7 +215,10 @@ final class FrenchAnalyzerBuilder private[lucene] (
     copy(config.copy(lowerCase = true), stemmer = true)
 
   def build[F[_]](implicit F: Sync[F]): Resource[F, Analyzer] =
-    mkFromStandardTokenizer(config)(ts => if (self.stemmer) new FrenchLightStemFilter(ts) else ts)
+    mkFromStandardTokenizer(config) { ts =>
+      val tokens = if (self.config.defaultStopWords) new StopFilter(ts, getFrenchStopSet()) else ts
+      if (self.stemmer) new FrenchLightStemFilter(tokens) else tokens
+    }
 }
 
 final class SpanishAnalyzerBuilder private[lucene] (
@@ -215,9 +233,14 @@ final class SpanishAnalyzerBuilder private[lucene] (
   ): SpanishAnalyzerBuilder =
     new SpanishAnalyzerBuilder(newConfig, stemmer)
 
-  def defaultStopWords: CharArraySet = getSpanishStopSet()
   def withConfig(newConfig: Config): SpanishAnalyzerBuilder =
     copy(newConfig = newConfig)
+
+  /** A convenience value for debugging or investigating, to inspect the Lucene default stop words.
+    * This set is immutable, and unused; it is the underlying Lucene `CharArraySet` that we use to
+    * build the default StopFilter
+    */
+  lazy val defaultStopWords: Set[String] = getSpanishStopSet().asScala.map(_.toString()).toSet
 
   /** Adds the SpanishLight Stemmer to the end of the analyzer pipeline and enables lowercasing.
     * Stemming reduces words like `jumping` and `jumps` to their root word `jump`.
@@ -227,7 +250,10 @@ final class SpanishAnalyzerBuilder private[lucene] (
     copy(config.copy(lowerCase = true), stemmer = true)
 
   def build[F[_]](implicit F: Sync[F]): Resource[F, Analyzer] =
-    mkFromStandardTokenizer(config)(ts => if (self.stemmer) new SpanishLightStemFilter(ts) else ts)
+    mkFromStandardTokenizer(config) { ts =>
+      val tokens = if (self.config.defaultStopWords) new StopFilter(ts, getSpanishStopSet()) else ts
+      if (self.stemmer) new SpanishLightStemFilter(tokens) else tokens
+    }
 }
 
 final class ItalianAnalyzerBuilder private[lucene] (
@@ -242,9 +268,14 @@ final class ItalianAnalyzerBuilder private[lucene] (
   ): ItalianAnalyzerBuilder =
     new ItalianAnalyzerBuilder(newConfig, stemmer)
 
-  def defaultStopWords: CharArraySet = getItalianStopSet()
   def withConfig(newConfig: Config): ItalianAnalyzerBuilder =
     copy(newConfig = newConfig)
+
+  /** A convenience value for debugging or investigating, to inspect the Lucene default stop words.
+    * This set is immutable, and unused; it is the underlying Lucene `CharArraySet` that we use to
+    * build the default StopFilter
+    */
+  lazy val defaultStopWords: Set[String] = getItalianStopSet().asScala.map(_.toString()).toSet
 
   /** Adds the ItalianLight Stemmer to the end of the analyzer pipeline and enables lowercasing.
     * Stemming reduces words like `jumping` and `jumps` to their root word `jump`.
@@ -254,7 +285,10 @@ final class ItalianAnalyzerBuilder private[lucene] (
     copy(config.copy(lowerCase = true), stemmer = true)
 
   def build[F[_]](implicit F: Sync[F]): Resource[F, Analyzer] =
-    mkFromStandardTokenizer(config)(ts => if (self.stemmer) new ItalianLightStemFilter(ts) else ts)
+    mkFromStandardTokenizer(config) { ts =>
+      val tokens = if (self.config.defaultStopWords) new StopFilter(ts, getItalianStopSet()) else ts
+      if (self.stemmer) new ItalianLightStemFilter(tokens) else tokens
+    }
 }
 
 final class GermanAnalyzerBuilder private[lucene] (
@@ -269,9 +303,14 @@ final class GermanAnalyzerBuilder private[lucene] (
   ): GermanAnalyzerBuilder =
     new GermanAnalyzerBuilder(newConfig, stemmer)
 
-  def defaultStopWords: CharArraySet = getGermanStopSet()
   def withConfig(newConfig: Config): GermanAnalyzerBuilder =
     copy(newConfig = newConfig)
+
+  /** A convenience value for debugging or investigating, to inspect the Lucene default stop words.
+    * This set is immutable, and unused; it is the underlying Lucene `CharArraySet` that we use to
+    * build the default StopFilter
+    */
+  lazy val defaultStopWords: Set[String] = getGermanStopSet().asScala.map(_.toString()).toSet
 
   /** Adds the GermanLight Stemmer to the end of the analyzer pipeline and enables lowercasing.
     * Stemming reduces words like `jumping` and `jumps` to their root word `jump`.
@@ -281,5 +320,8 @@ final class GermanAnalyzerBuilder private[lucene] (
     copy(config.copy(lowerCase = true), stemmer = true)
 
   def build[F[_]](implicit F: Sync[F]): Resource[F, Analyzer] =
-    mkFromStandardTokenizer(config)(ts => if (self.stemmer) new GermanLightStemFilter(ts) else ts)
+    mkFromStandardTokenizer(config) { ts =>
+      val tokens = if (self.config.defaultStopWords) new StopFilter(ts, getGermanStopSet()) else ts
+      if (self.stemmer) new GermanLightStemFilter(tokens) else tokens
+    }
 }

--- a/lucene/src/test/scala/textmogrify/lucene/AnalyzerBuilderSuite.scala
+++ b/lucene/src/test/scala/textmogrify/lucene/AnalyzerBuilderSuite.scala
@@ -42,8 +42,8 @@ class DefaultAnalyzerBuilderSuite extends CatsEffectSuite {
     assertIO(actual, Vector("I", "Like", "Jalapenos"))
   }
 
-  test("default analyzer withStopWords should filter them out") {
-    val analyzer = AnalyzerBuilder.default.withStopWords(Set("I"))
+  test("default analyzer withCustomStopWords should filter them out") {
+    val analyzer = AnalyzerBuilder.default.withCustomStopWords(Set("I"))
     val actual = analyzer.tokenizer[IO].use(f => f(jalapenos))
     assertIO(actual, Vector("Like", "Jalapeños"))
   }
@@ -73,8 +73,8 @@ class EnglishAnalyzerBuilderSuite extends CatsEffectSuite {
     assertIO(actual, Vector("I", "Like", "Jalapenos"))
   }
 
-  test("english analyzer withStopWords should filter them out") {
-    val analyzer = AnalyzerBuilder.english.withStopWords(Set("I"))
+  test("english analyzer withCustomStopWords should filter them out") {
+    val analyzer = AnalyzerBuilder.english.withCustomStopWords(Set("I"))
     val actual = analyzer.tokenizer[IO].use(f => f(jalapenos))
     assertIO(actual, Vector("Like", "Jalapeños"))
   }
@@ -87,7 +87,7 @@ class EnglishAnalyzerBuilderSuite extends CatsEffectSuite {
 
   test("english analyzer builder settings can be chained") {
     val analyzer = AnalyzerBuilder.english.withPorterStemmer
-      .withStopWords(Set("on"))
+      .withCustomStopWords(Set("on"))
       .withASCIIFolding
       .withLowerCasing
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
@@ -119,8 +119,8 @@ class FrenchAnalyzerBuilderSuite extends CatsEffectSuite {
     assertIO(actual, Vector("J'aime", "Les", "Jalapenos"))
   }
 
-  test("french analyzer withStopWords should filter them out") {
-    val analyzer = AnalyzerBuilder.french.withStopWords(Set("Les"))
+  test("french analyzer withCustomStopWords should filter them out") {
+    val analyzer = AnalyzerBuilder.french.withCustomStopWords(Set("Les"))
     val actual = analyzer.tokenizer[IO].use(f => f(jalapenos))
     assertIO(actual, Vector("J'aime", "Jalapeños"))
   }
@@ -134,7 +134,7 @@ class FrenchAnalyzerBuilderSuite extends CatsEffectSuite {
 
   test("french analyzer builder settings can be chained") {
     val analyzer = AnalyzerBuilder.french.withFrenchLightStemmer
-      .withStopWords(Set("on"))
+      .withCustomStopWords(Set("on"))
       .withASCIIFolding
       .withLowerCasing
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
@@ -166,8 +166,8 @@ class SpanishAnalyzerBuilderSuite extends CatsEffectSuite {
     assertIO(actual, Vector("Me", "gustan", "los", "jalapenos"))
   }
 
-  test("spanish analyzer withStopWords should filter them out") {
-    val analyzer = AnalyzerBuilder.spanish.withStopWords(Set("le", "los"))
+  test("spanish analyzer withCustomStopWords should filter them out") {
+    val analyzer = AnalyzerBuilder.spanish.withCustomStopWords(Set("le", "los"))
     val actual = analyzer.tokenizer[IO].use(f => f(jalapenos))
     assertIO(actual, Vector("Me", "gustan", "jalapeños"))
   }
@@ -181,7 +181,7 @@ class SpanishAnalyzerBuilderSuite extends CatsEffectSuite {
 
   test("spanish analyzer builder settings can be chained") {
     val analyzer = AnalyzerBuilder.spanish.withSpanishLightStemmer
-      .withStopWords(Set("le", "los"))
+      .withCustomStopWords(Set("le", "los"))
       .withASCIIFolding
       .withLowerCasing
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
@@ -213,8 +213,8 @@ class ItalianAnalyzerBuilderSuite extends CatsEffectSuite {
     assertIO(actual, Vector("Mi", "piacciono", "i", "jalapenos"))
   }
 
-  test("italian analyzer withStopWords should filter them out") {
-    val analyzer = AnalyzerBuilder.italian.withStopWords(Set("i"))
+  test("italian analyzer withCustomStopWords should filter them out") {
+    val analyzer = AnalyzerBuilder.italian.withCustomStopWords(Set("i"))
     val actual = analyzer.tokenizer[IO].use(f => f(jalapenos))
     assertIO(actual, Vector("Mi", "piacciono", "jalapeños"))
   }
@@ -227,7 +227,7 @@ class ItalianAnalyzerBuilderSuite extends CatsEffectSuite {
 
   test("italian analyzer builder settings can be chained") {
     val analyzer = AnalyzerBuilder.italian.withItalianLightStemmer
-      .withStopWords(Set("a", "sui"))
+      .withCustomStopWords(Set("a", "sui"))
       .withASCIIFolding
       .withLowerCasing
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
@@ -259,8 +259,8 @@ class GermanAnalyzerBuilderSuite extends CatsEffectSuite {
     assertIO(actual, Vector("Ich", "mag", "Jalapenos"))
   }
 
-  test("german analyzer withStopWords should filter them out") {
-    val analyzer = AnalyzerBuilder.german.withStopWords(Set("Ich"))
+  test("german analyzer withCustomStopWords should filter them out") {
+    val analyzer = AnalyzerBuilder.german.withCustomStopWords(Set("Ich"))
     val actual = analyzer.tokenizer[IO].use(f => f(jalapenos))
     assertIO(actual, Vector("mag", "Jalapeños"))
   }
@@ -273,7 +273,7 @@ class GermanAnalyzerBuilderSuite extends CatsEffectSuite {
 
   test("german analyzer builder settings can be chained") {
     val analyzer = AnalyzerBuilder.german.withGermanLightStemmer
-      .withStopWords(Set("auf"))
+      .withCustomStopWords(Set("auf"))
       .withASCIIFolding
       .withLowerCasing
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))

--- a/lucene/src/test/scala/textmogrify/lucene/AnalyzerBuilderSuite.scala
+++ b/lucene/src/test/scala/textmogrify/lucene/AnalyzerBuilderSuite.scala
@@ -79,6 +79,12 @@ class EnglishAnalyzerBuilderSuite extends CatsEffectSuite {
     assertIO(actual, Vector("Like", "Jalapeños"))
   }
 
+  test("english analyzer withDefaultStopWords should filter them out") {
+    val analyzer = AnalyzerBuilder.english.withDefaultStopWords
+    val actual = analyzer.tokenizer[IO].use(f => f(jumping))
+    assertIO(actual, Vector("Neeko", "likes", "jumping", "counters"))
+  }
+
   test("english analyzer withPorterStemmer should lowercase and stem words") {
     val analyzer = AnalyzerBuilder.english.withPorterStemmer
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
@@ -87,11 +93,12 @@ class EnglishAnalyzerBuilderSuite extends CatsEffectSuite {
 
   test("english analyzer builder settings can be chained") {
     val analyzer = AnalyzerBuilder.english.withPorterStemmer
-      .withCustomStopWords(Set("on"))
+      .withCustomStopWords(Set("counters"))
+      .withDefaultStopWords
       .withASCIIFolding
       .withLowerCasing
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
-    assertIO(actual, Vector("neeko", "like", "jump", "counter"))
+    assertIO(actual, Vector("neeko", "like", "jump"))
   }
 
 }
@@ -125,6 +132,12 @@ class FrenchAnalyzerBuilderSuite extends CatsEffectSuite {
     assertIO(actual, Vector("J'aime", "Jalapeños"))
   }
 
+  test("french analyzer withDefaultStopWords should filter them out") {
+    val analyzer = AnalyzerBuilder.french.withDefaultStopWords
+    val actual = analyzer.tokenizer[IO].use(f => f(jumping))
+    assertIO(actual, Vector("Neeko", "aime", "sauter", "compteurs"))
+  }
+
   test("french analyzer withFrenchLightStemmer should lowercase and stem words") {
     val analyzer = AnalyzerBuilder.french.withFrenchLightStemmer
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
@@ -134,11 +147,12 @@ class FrenchAnalyzerBuilderSuite extends CatsEffectSuite {
 
   test("french analyzer builder settings can be chained") {
     val analyzer = AnalyzerBuilder.french.withFrenchLightStemmer
-      .withCustomStopWords(Set("on"))
+      .withCustomStopWords(Set("neeko"))
+      .withDefaultStopWords
       .withASCIIFolding
       .withLowerCasing
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
-    assertIO(actual, Vector("neko", "aime", "saut", "sur", "les", "compt"))
+    assertIO(actual, Vector("aime", "saut", "compt"))
   }
 
 }
@@ -172,6 +186,12 @@ class SpanishAnalyzerBuilderSuite extends CatsEffectSuite {
     assertIO(actual, Vector("Me", "gustan", "jalapeños"))
   }
 
+  test("spanish analyzer withDefaultStopWords should filter them out") {
+    val analyzer = AnalyzerBuilder.spanish.withDefaultStopWords
+    val actual = analyzer.tokenizer[IO].use(f => f(jumping))
+    assertIO(actual, Vector("A", "Neeko", "gusta", "saltar", "mostradores"))
+  }
+
   test("spanish analyzer withSpanishLightStemmer should lowercase and stem words") {
     val analyzer = AnalyzerBuilder.spanish.withSpanishLightStemmer
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
@@ -181,11 +201,12 @@ class SpanishAnalyzerBuilderSuite extends CatsEffectSuite {
 
   test("spanish analyzer builder settings can be chained") {
     val analyzer = AnalyzerBuilder.spanish.withSpanishLightStemmer
-      .withCustomStopWords(Set("le", "los"))
+      .withCustomStopWords(Set("neeko"))
+      .withDefaultStopWords
       .withASCIIFolding
       .withLowerCasing
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
-    assertIO(actual, Vector("a", "neek", "gust", "saltar", "sobr", "mostrador"))
+    assertIO(actual, Vector("gust", "saltar", "mostrador"))
   }
 
 }
@@ -219,6 +240,12 @@ class ItalianAnalyzerBuilderSuite extends CatsEffectSuite {
     assertIO(actual, Vector("Mi", "piacciono", "jalapeños"))
   }
 
+  test("italian analyzer withDefaultStopWords should filter them out") {
+    val analyzer = AnalyzerBuilder.italian.withDefaultStopWords
+    val actual = analyzer.tokenizer[IO].use(f => f(jumping))
+    assertIO(actual, Vector("A", "Neeko", "piace", "saltare", "contatori"))
+  }
+
   test("italian analyzer withItalianLightStemmer should lowercase and stem words") {
     val analyzer = AnalyzerBuilder.italian.withItalianLightStemmer
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
@@ -227,11 +254,12 @@ class ItalianAnalyzerBuilderSuite extends CatsEffectSuite {
 
   test("italian analyzer builder settings can be chained") {
     val analyzer = AnalyzerBuilder.italian.withItalianLightStemmer
-      .withCustomStopWords(Set("a", "sui"))
+      .withCustomStopWords(Set("neeko"))
+      .withDefaultStopWords
       .withASCIIFolding
       .withLowerCasing
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
-    assertIO(actual, Vector("neeko", "piace", "saltar", "contator"))
+    assertIO(actual, Vector("piace", "saltar", "contator"))
   }
 
 }
@@ -265,6 +293,12 @@ class GermanAnalyzerBuilderSuite extends CatsEffectSuite {
     assertIO(actual, Vector("mag", "Jalapeños"))
   }
 
+  test("german analyzer withDefaultStopWords should filter them out") {
+    val analyzer = AnalyzerBuilder.german.withDefaultStopWords
+    val actual = analyzer.tokenizer[IO].use(f => f(jumping))
+    assertIO(actual, Vector("Neeko", "springt", "gerne", "Theken"))
+  }
+
   test("german analyzer withGermanLightStemmer should lowercase and stem words") {
     val analyzer = AnalyzerBuilder.german.withGermanLightStemmer
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
@@ -273,11 +307,12 @@ class GermanAnalyzerBuilderSuite extends CatsEffectSuite {
 
   test("german analyzer builder settings can be chained") {
     val analyzer = AnalyzerBuilder.german.withGermanLightStemmer
-      .withCustomStopWords(Set("auf"))
+      .withCustomStopWords(Set("Neeko"))
+      .withDefaultStopWords
       .withASCIIFolding
       .withLowerCasing
     val actual = analyzer.tokenizer[IO].use(f => f(jumping))
-    assertIO(actual, Vector("neeko", "springt", "gern", "thek"))
+    assertIO(actual, Vector("springt", "gern", "thek"))
   }
 
 }


### PR DESCRIPTION
# what
- renames `withStopWords` to `withCustomStopWords`
- adds a `withDefaultStopWords`, and helper val to see what those default words are
- updates the multilingual pipeline to use default stop words filter in the base, it's super sweet 😎 

# why
- this lets someone easily use a default stop filter without having to look up a reasonable stop list in their chosen language
- but they can also add a custom stop filter that combines with the default filter (or they could only use the custom filter)

resolves #26 